### PR TITLE
add .cmd to run MTS with bundled jdk

### DIFF
--- a/MTS.cmd
+++ b/MTS.cmd
@@ -1,0 +1,1 @@
+start  .\jre\bin\java.exe -jar .\ModTheSpire.jar

--- a/README.md
+++ b/README.md
@@ -1,29 +1,33 @@
 # ModTheSpire #
 ModTheSpire is a tool to load external mods for Slay the Spire without modifying the base game files.
 
-## Requirements ##
-#### General Use ####
-* Java 8
-
-#### Development ####
-* Java 8
-* Maven
-
-## Building ##
-1. Run `mvn package`
-
-## Installation ##
-1. Copy `target/ModTheSpire.jar` to your Slay the Spire install directory.
-2. Create a `mods` directory. Place mod JAR files into the `mods` directory.
-
 ## Usage ##
-1. Run `ModTheSpire.jar`.
+### Windows ###
+#### Installation ####
+1. Download the latest Release
+2. Copy `ModTheSpire.jar` and `MTS.cmd` to your Slay the Spire install directory.
+3. Create a `mods` directory. Place mod JAR files into the `mods` directory.
+
+#### Running Mods ####
+1. Run `MTS.cmd`.
 2. Select the mod(s) you want to use.
 3. Press 'Play'.
 
+---
+
 ## For Modders ##
+#### Requirements ####
+* JDK 8
+* Maven
+
+#### General ####
 * ModTheSpire automatically sets the Settings.isModded flag to true, so there is no need to do that yourself.
 * [Wiki](https://github.com/kiooeht/ModTheSpire/wiki/SpirePatch)
+
+#### Building ####
+1. Run `mvnw package`
+
+---
 
 ## Changelog ##
 #### v2.5.0 ####


### PR DESCRIPTION
As multiple people have had problems running MTS and downloading jre in the past.

This add a script to run MTS with the bundled JRE under windows. 

mts.cmd should then be included in releases

