### PR TITLE
Don't crash on malformed json

### DIFF
--- a/src/main/java/com/evacipated/cardcrawl/modthespire/ModInfo.java
+++ b/src/main/java/com/evacipated/cardcrawl/modthespire/ModInfo.java
@@ -95,7 +95,7 @@ public class ModInfo implements Serializable
             }
         }
 
-        return null;
+        return ReadModInfoOld(mod_jar);
     }
 
     private static ModInfo ReadModInfoOld(File mod_jar)


### PR DESCRIPTION
ModTheSpire would throw a NullPointerException and refuse to start if a mod had malformed JSON for it's `ModTheSpire.json`. This commit makes ModTheSpire just load the old ModInfo type if loading JSON fails while still printing an error message to the console in the case of failure.