### PR TITLE
Show mods that are in stacktrace on crash

### DIFF
--- a/src/main/java/com/evacipated/cardcrawl/modthespire/patches/DisableGdxForceExit.java
+++ b/src/main/java/com/evacipated/cardcrawl/modthespire/patches/DisableGdxForceExit.java
@@ -7,6 +7,12 @@ import javassist.CannotCompileException;
 import javassist.expr.ExprEditor;
 import javassist.expr.FieldAccess;
 
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 @SpirePatch(
     clz=LwjglApplication.class,
     method="mainLoop"
@@ -20,7 +26,7 @@ public class DisableGdxForceExit
         if (crash != null) {
             System.err.println("Game crashed.");
             Loader.printMTSInfo(System.err);
-            tryPrintModsInStacktrace();
+            tryPrintModsInStacktrace(crash);
             System.err.println("Cause:");
             crash.printStackTrace();
             Loader.restoreWindowOnCrash();


### PR DESCRIPTION
When StS crashes, show mods that are in stacktrace. This is because some modders didn't put their modid to package name and it's hard to locate which mod caused the issue.

Here's the screenshot:
![Screenshot1](https://user-images.githubusercontent.com/7110965/157491104-d18695a3-50cf-486c-ab80-44a893e395f2.png)
