### PR TITLE
improvement(loader): add property parsers for all flags

### DIFF
--- a/src/main/java/com/evacipated/cardcrawl/modthespire/Loader.java
+++ b/src/main/java/com/evacipated/cardcrawl/modthespire/Loader.java
@@ -139,6 +139,13 @@ public class Loader
             Properties defaults = new Properties();
             defaults.setProperty("debug", Boolean.toString(false));
             defaults.setProperty("out-jar", Boolean.toString(false));
+            defaults.setProperty("package", Boolean.toString(false));
+            defaults.setProperty("close-when-finished", Boolean.toString(false));
+            defaults.setProperty("allow-beta", Boolean.toString(false));
+            defaults.setProperty("skip-launcher", Boolean.toString(false));
+            defaults.setProperty("skip-intro", Boolean.toString(false));
+            defaults.setProperty("profile", ModList.getDefaultList());
+            defaults.setProperty("mods", "");
             defaults.putAll(ModSelectWindow.getDefaults());
             MTS_CONFIG = new SpireConfig(null, "ModTheSpire", defaults);
         } catch (IOException e) {

--- a/src/main/java/com/evacipated/cardcrawl/modthespire/Loader.java
+++ b/src/main/java/com/evacipated/cardcrawl/modthespire/Loader.java
@@ -141,7 +141,7 @@ public class Loader
             defaults.setProperty("out-jar", Boolean.toString(false));
             defaults.setProperty("package", Boolean.toString(false));
             defaults.setProperty("close-when-finished", Boolean.toString(false));
-            defaults.setProperty("allow-beta", Boolean.toString(false));
+            defaults.setProperty("allow-beta", Boolean.toString(true));
             defaults.setProperty("skip-launcher", Boolean.toString(false));
             defaults.setProperty("skip-intro", Boolean.toString(false));
             defaults.setProperty("profile", ModList.getDefaultList());
@@ -175,7 +175,6 @@ public class Loader
             CLOSE_WHEN_FINISHED = true;
         }
 
-        allowBeta = true;
         if (argList.contains("--allow-beta")) {
             allowBeta = true;
         }

--- a/src/main/java/com/evacipated/cardcrawl/modthespire/Loader.java
+++ b/src/main/java/com/evacipated/cardcrawl/modthespire/Loader.java
@@ -146,6 +146,13 @@ public class Loader
         }
         DEBUG = MTS_CONFIG.getBool("debug");
         OUT_JAR = MTS_CONFIG.getBool("out-jar");
+        PACKAGE = MTS_CONFIG.getBool("package");
+        CLOSE_WHEN_FINISHED = MTS_CONFIG.getBool("close-when-finished");
+        allowBeta = MTS_CONFIG.getBool("allow-beta");
+        boolean skipLauncher = MTS_CONFIG.getBool("skip-launcher");
+        SKIP_INTRO = MTS_CONFIG.getBool("skip-intro");
+        profileArg = MTS_CONFIG.getString("profile");
+        String modIds = MTS_CONFIG.getString("mods");
 
         if (argList.contains("--debug")) {
             DEBUG = true;
@@ -166,8 +173,12 @@ public class Loader
             allowBeta = true;
         }
 
-        boolean skipLauncher = argList.contains("--skip-launcher");
-        SKIP_INTRO = argList.contains("--skip-intro");
+        if (argList.contains("--skip-launcher")) {
+            skipLauncher = true;
+        }
+        if (argList.contains("--skip-intro")) {
+            SKIP_INTRO = true;
+        }
 
         int profileArgIndex = argList.indexOf("--profile");
         if (profileArgIndex >= 0 && argList.size() > profileArgIndex + 1) {
@@ -176,7 +187,9 @@ public class Loader
 
         int modIdsIndex = argList.indexOf("--mods");
         if (modIdsIndex >= 0 && argList.size() > modIdsIndex + 1) {
-            String modIds = argList.get(modIdsIndex+1);
+            modIds = argList.get(modIdsIndex+1);
+        }
+        if (!modIds.isEmpty()) {
             manualModIds = Arrays.asList(modIds.split(","));
             profileArg = null;
             skipLauncher = true;


### PR DESCRIPTION
I'm not sure if I'm just doing something wrong or if steam only passes flags when selecting `Play Slay the Spire` and not to `Play With Mods` but with the Steam Deck not displaying the java UI of ModTheSpire quite right (black screen unless I'm moving the mouse by touching the screen) I wanted to skip the launcher most of the time when launching it and have my mods that I want enabled selected already as part of my default profile. Thought adding all the flags to the properties file and then setting the skip-launcher flag in that accordingly would do it.

I also noticed that there seemed to be a flag left lingering out there where it's impossible to have allowBeta==false because it's set to true whether or not the flag was set, figured that was done 4 years ago for a reason but moving that to a true default property, I wouldn't mind undoing that if desired