### PR TITLE
Support scala mod

### DIFF
--- a/src/main/java/com/evacipated/cardcrawl/modthespire/PackageJar.java
+++ b/src/main/java/com/evacipated/cardcrawl/modthespire/PackageJar.java
@@ -247,6 +247,10 @@ class PackageJar
                     Set<String> initializers = Patcher.annotationDBMap.get(info.jarURL).getAnnotationIndex().get(SpireInitializer.class.getName());
                     if (initializers != null) {
                         for (String initializer : initializers) {
+                            if (initializer.endsWith("$")) {
+                                // Skip scala singleton class for object
+                                continue;
+                            }
                             src.append(initializer).append(".");
                             if (info.ID.startsWith("__sideload_")) {
                                 try {

--- a/src/main/java/com/evacipated/cardcrawl/modthespire/Patcher.java
+++ b/src/main/java/com/evacipated/cardcrawl/modthespire/Patcher.java
@@ -36,6 +36,10 @@ public class Patcher {
                 if (initializers != null) {
                     System.out.println(" - " + info.Name);
                     for (String initializer : initializers) {
+                        if (initializer.endsWith("$")) {
+                            // Skip scala singleton class for object
+                            continue;
+                        }
                         System.out.println("   - " + initializer);
                         try {
                             long startTime = System.nanoTime();


### PR DESCRIPTION
Scala doesn't have static method. In following example, `@SpireInitializer` on `MyMod$` cases crash because its `initialize` is not static. I'm not sure whether this affects other JVM languages such as Kotlin. Can you please test it with mods in Kotlin, too?
Code:
```Scala
@SpireInitialzer
object MyMod {
  def initialize() = ???
}
```
is compiled to:
```Java
@SpireInitialzer
public class MyMod {
  public static void initialize() { MyMod$.MODULE$.initialize(); }
}

@SpireInitialzer
public class MyMod$ {
  public static MyMod$ MODULE$ = new MyMod$();
  public void initialize() { throw NIE(); }
}
```