### PR TITLE
Add SpireMethod patch in ClassPatchInfo for more convenient to adding methods to classes.

### DIFF
--- a/src/main/java/com/evacipated/cardcrawl/modthespire/lib/SpireMethod.java
+++ b/src/main/java/com/evacipated/cardcrawl/modthespire/lib/SpireMethod.java
@@ -1,0 +1,16 @@
+package com.evacipated.cardcrawl.modthespire.lib;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SpireMethod {
+    String onConflict() default "Postfix";
+
+    String POSTFIX = "Postfix";
+
+    String PREFIX = "Prefix";
+}


### PR DESCRIPTION
After add this feature, you can add a method to a class like this:

    @SpirePatch(
            clz = RunicDome.class,
            method = SpirePatch.CLASS
    )
    public static class PatchRunicDome {
        //this will add onSpawnMonster(AbstractMonster) method to RunicDome
        @SpireMethod
        public static void onSpawnMonster(AbstractRelic runicDome, AbstractMonster monster) {
            runicDome.flash();
            AbstractDungeon.actionManager.addToBottom(new RelicAboveCreatureAction(monster, runicDome));
        }
    }

If another mod has already added this method, the method body will insert into the existing method.

    @SpirePatch(
            clz = RunicDome.class,
            method = SpirePatch.CLASS
    )
    public static class TestConflict {
        private static final AbstractRelic mask = new CultistMask();

        @SpireMethod(onConflict = SpireMethod.PREFIX)
        public static void onSpawnMonster(AbstractRelic runicDome, AbstractMonster monster) {
            AbstractDungeon.actionManager.addToBottom(new RelicAboveCreatureAction(AbstractDungeon.player, runicDome));
            AbstractDungeon.actionManager.addToBottom(new SFXAction("VO_CULTIST_1A"));
            AbstractDungeon.actionManager.addToBottom(new TalkAction(true, mask.DESCRIPTIONS[1], 1.0F, 2.0F));
        }
    }
