### PR TITLE
add a divider and allow users to add aliases for mods

### DIFF
--- a/src/main/java/com/evacipated/cardcrawl/modthespire/ui/JModPanelCheckBoxList.java
+++ b/src/main/java/com/evacipated/cardcrawl/modthespire/ui/JModPanelCheckBoxList.java
@@ -44,7 +44,13 @@ public class JModPanelCheckBoxList extends JList<ModPanel> {
                         if (modPanel.checkBox.isEnabled()) {
                             modPanel.checkBox.setSelected(!modPanel.checkBox.isSelected());
                             repaint();
+                            return;
                         }
+                    }
+
+                    if (e.getClickCount() == 2) {
+                        String alias = JOptionPane.showInputDialog("Please enter an alias:");
+                        modPanel.setAlias(alias);
                     }
                 }
             }

--- a/src/main/java/com/evacipated/cardcrawl/modthespire/ui/ModPanel.java
+++ b/src/main/java/com/evacipated/cardcrawl/modthespire/ui/ModPanel.java
@@ -9,6 +9,7 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.border.MatteBorder;
 import java.awt.*;
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 
 @SuppressWarnings("serial")
@@ -96,6 +97,8 @@ public class ModPanel extends JPanel
             parent.publishBoxChecked();
         });
         parent.publishBoxChecked();
+
+        setToolTipText("Double click to add an alias for this mod");
     }
     
     public void recalcModWarnings(JModPanelCheckBoxList parent)
@@ -196,7 +199,7 @@ public class ModPanel extends JPanel
             System.out.println("ModPanel.filter failed to get workshop info of " + info.ID + ": " + ex);
         }
 
-        String modInfoKey = String.format("%s %s %s %s", info.ID, info.Name, String.join(" ", info.Authors), workshopInfoKey).toLowerCase();
+        String modInfoKey = String.format("%s %s %s %s %s", info.ID, info.Name, infoPanel.alias, String.join(" ", info.Authors), workshopInfoKey).toLowerCase();
         boolean isFilteredOut = false;
         for (String filterKey : filterKeys) {
             if (!modInfoKey.contains(filterKey)) {
@@ -211,8 +214,21 @@ public class ModPanel extends JPanel
         return isFilteredOut;
     }
 
+    // set the alias for this mod and save
+    public void setAlias(String alias) {
+        if (alias == null || alias.isEmpty()) return;
+        infoPanel.setNameText(alias);
+        Loader.MTS_CONFIG.setString(info.ID, alias);
+        try {
+            Loader.MTS_CONFIG.save();
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
+    }
+
     public class InfoPanel extends JPanel
     {
+        String alias = "";
         JLabel name = new JLabel();
         JLabel version = new JLabel();
 
@@ -234,8 +250,21 @@ public class ModPanel extends JPanel
             }
             add(version, BorderLayout.SOUTH);
 
+            String alias = Loader.MTS_CONFIG.getString(info.ID);
+            setNameText(alias);
+
             checkBox.setBackground(Color.WHITE);
             setBackground(Color.WHITE);
+        }
+
+        public void setNameText(String alias) {
+            if (alias == null) return;
+            this.alias = alias;
+            if (alias.isEmpty()) {
+                name.setText(info.Name);
+            } else {
+                name.setText(String.format("<html>[%s]  <font color=#a0a0a0>%s</font></html>", alias, info.Name));
+            }
         }
 
         @Override


### PR DESCRIPTION
1. A divider is added between mod select pane and mod info pane so that users can freely change the layout.
![QQ截图20230217124246](https://user-images.githubusercontent.com/57124662/219551342-a3a8eef0-8075-42c1-b81b-5b57fcde7613.png)

2. Now users can add aliases for each mod by double-click and use them to search in the filter.
![QQ截图20230217124456](https://user-images.githubusercontent.com/57124662/219551500-9d2ddd12-c80f-4de2-8f22-51179767668e.png)
![QQ截图20230217124230](https://user-images.githubusercontent.com/57124662/219551358-988bec2f-7ed2-4273-b81c-264b01da89bc.png)
